### PR TITLE
fix: correct spelling of 'least' in disk space warning

### DIFF
--- a/pkgbasify.lua
+++ b/pkgbasify.lua
@@ -531,7 +531,7 @@ local function check_disk_space()
 	else
 		print([[
 Less than 5GiB space available on the root filesystem.
-It is recommended to have at lest 5GiB available before conversion as pkg does
+It is recommended to have at least 5GiB available before conversion as pkg does
 not detect and handle insufficient space gracefully during installation.
 ]])
 		return prompt_yn("Continue despite possibly insufficient disk space?")


### PR DESCRIPTION
Hi!

Corrected a minor typo in the `check_disk_space()` function's error message, changing "at lest" to "at least" for clearer console output. 

Note for maintainers: I also noticed a small typo in the `freebsd_version()` comments where "RxLEASE" is written instead of "RELEASE". I didn't include the fix in this commit to keep the scope tight, but wanted to point it out.